### PR TITLE
Async postconditions in generics

### DIFF
--- a/Foxtrot/Driver/Rewriting/EmitAsyncClosure.cs
+++ b/Foxtrot/Driver/Rewriting/EmitAsyncClosure.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Compiler;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading.Tasks;
@@ -59,6 +58,121 @@ namespace Microsoft.Contracts.Foxtrot
     /// </remarks>
     internal class EmitAsyncClosure : StandardVisitor
     {
+        /// <summary>
+        /// Class that maps generic arguments of the enclosed class/method the generic arguments of the closure.
+        /// </summary>
+        /// <remarks>
+        /// The problem.
+        /// Original implementation of the Code Contract didn't support async postconditions in generics.
+        /// Here is why:
+        /// Suppose we have following function (in class <code>Foo</code>:
+        /// <code><![CDATA[
+        /// public static Task<T> FooAsync() where T: class
+        /// {
+        ///     Contract.Ensures(Contract.Result<T>() != null);
+        /// }
+        /// ]]></code>
+        /// In this case, ccrewrite will generate async closure class called <code>Foo.AsyncContractClosure_0&lt;T%gt;</T></code> 
+        /// with following structure:
+        /// <code><![CDATA[
+        /// [CompilerGenerated]
+        /// private class <Foo>AsyncContractClosure_0<T> where T : class
+        /// {
+        /// 	public Task<T> CheckPost(Task<T> task)
+        /// 	{
+        /// 		TaskStatus status = task.Status;
+        /// 		if (status == TaskStatus.RanToCompletion)
+        /// 		{
+        /// 			RewriterMethods.Ensures(task.Result != null, null, "Contract.Result<T>() != null");
+        /// 		}
+        /// 		return task;
+        /// 	}
+        /// }
+        /// ]]>
+        /// </code>
+        /// The code looks good, but the IL could be invalid (without the trick that this class provides).
+        /// Postcondition of the method in our case is declared in the generic method (in <code>FooAsync</code>)
+        /// but ccrewrite moves it into non-generic method (<code>CheckPost</code>) of the generic class (closure).
+        /// 
+        /// But on IL level there is different instructions for referencing method generic arguments and type generic arguments.
+        /// 
+        /// After changing <code>Contract.Result</code> to <code>task.Result</code> and moving postcondition to <code>CheckPost</code>
+        /// method, following IL would be generated:
+        /// 
+        /// <code> <![CDATA[
+        /// IL_0011: call instance !0 class [mscorlib]System.Threading.Tasks.Task`1<!T>::get_Result()
+        /// IL_0016: box !!0 // <-- here is our problem!
+        /// ]]>
+        /// </code>
+        ///
+        /// This means that method <code>CheckPost</code> would contains a reference to generic method argument of the
+        /// original method.
+        /// 
+        /// The goal of this class is to store a mapping between enclosing generic types and closure generic types.
+        /// </remarks>
+        private class GenericTypeMapper
+        {
+            class TypeNodePair
+            {
+                public TypeNodePair(TypeNode enclosingGenericType, TypeNode closureGenericType)
+                {
+                    EnclosingGenericType = enclosingGenericType;
+                    ClosureGenericType = closureGenericType;
+                }
+
+                public TypeNode EnclosingGenericType { get; private set; }
+                public TypeNode ClosureGenericType { get; private set; }
+            }
+
+            // Mapping between enclosing generic type and closure generic type.
+            // This is a simple list not a dictionary, because number of generic arguments is very small.
+            // So linear complexity will not harm performance.
+            private List<TypeNodePair> typeParametersMapping = new List<TypeNodePair>();
+
+            public bool IsEmpty { get { return typeParametersMapping.Count == 0; } }
+
+            public void AddMapping(TypeNode enclosingGenericType, TypeNode closureGenericType)
+            {
+                typeParametersMapping.Add(new TypeNodePair(enclosingGenericType, closureGenericType));
+            }
+
+            /// <summary>
+            /// Returns associated generic type of the closure class by enclosing generic type (for instance, by
+            /// generic type of the enclosing generic method that uses current closure).
+            /// </summary>
+            /// <remarks>
+            /// Function returns the same argument if the matching argument does not exists.
+            /// </remarks>
+            public TypeNode GetClosureTypeParameterByEnclosingTypeParameter(TypeNode enclosingType)
+            {
+                if (enclosingType == null)
+                {
+                    return null;
+                }
+
+                var candidate = typeParametersMapping.FirstOrDefault(t => t.EnclosingGenericType == enclosingType);
+                return candidate != null ? candidate.ClosureGenericType : enclosingType;
+            }
+            
+            /// <summary>
+            /// Returns associated generic type of the closure class by enclosing generic type (for instance, by
+            /// generic type of the enclosing generic method that uses current closure).
+            /// </summary>
+            /// <remarks>
+            /// Function returns the same argument if the matching argument does not exists.
+            /// </remarks>
+            public TypeNode GetEnclosingTypeParamterByGenericTypeParameter(TypeNode closureType)
+            {
+                if (closureType == null)
+                {
+                    return null;
+                }
+
+                var candidate = typeParametersMapping.FirstOrDefault(t => t.ClosureGenericType == closureType);
+                return candidate != null ? candidate.EnclosingGenericType : closureType;
+            }
+        }
+
         // This assembly should be in this class but not in the SystemTypes from System.CompilerCC.
         // Moving this type there will lead to test failures and assembly resolution errors.
         private static readonly AssemblyNode/*!*/ SystemCoreAssembly = SystemTypes.GetSystemCoreAssembly(false, true);
@@ -91,6 +205,8 @@ namespace Microsoft.Contracts.Foxtrot
         private Local originalResultLocal;
         private Parameter checkMethodTaskParameter;
         private readonly TypeNode checkMethodTaskType;
+
+        private readonly GenericTypeMapper genericTypeMapper = new GenericTypeMapper();
 
         public EmitAsyncClosure(Method from, Rewriter rewriter)
         {
@@ -132,21 +248,45 @@ namespace Microsoft.Contracts.Foxtrot
             this.func2Type = new Cache<TypeNode>(() =>
                 HelperMethods.FindType(SystemTypes.SystemAssembly, StandardIds.System, Identifier.For("Func`2")));
 
-            if (from.IsGeneric)
+            // Should distinguish between generic enclosing method and non-generic method in enclosing type.
+            // In both cases generated closure should be generic.
+            Func<Method, TypeNodeList> getGenericTypesFrom = method =>
             {
-                this.closureClass.TemplateParameters = CreateTemplateParameters(closureClass, from, declaringType);
+                if (method.IsGeneric)
+                {
+                    return from.TemplateParameters;
+                }
+                
+                if (method.DeclaringType.IsGeneric)
+                {
+                    return method.DeclaringType.TemplateParameters;
+                }
+
+                return null;
+            };
+
+            var enclosingTemplateParameters = getGenericTypesFrom(from);
+
+            if (!enclosingTemplateParameters.IsNullOrEmpty())
+            {
+                this.closureClass.TemplateParameters = CreateTemplateParameters(closureClass, enclosingTemplateParameters, declaringType);
 
                 this.closureClass.IsGeneric = true;
                 this.closureClass.EnsureMangledName();
 
                 this.forwarder = new Specializer(
                     targetModule: this.declaringType.DeclaringModule,
-                    pars: from.TemplateParameters,
+                    pars: enclosingTemplateParameters,
                     args: this.closureClass.TemplateParameters);
 
                 this.forwarder.VisitTypeParameterList(this.closureClass.TemplateParameters);
 
                 taskType = this.forwarder.VisitTypeReference(taskType);
+
+                for (int i = 0; i < enclosingTemplateParameters.Count; i++)
+                {
+                    this.genericTypeMapper.AddMapping(enclosingTemplateParameters[i], closureClass.TemplateParameters[i]);
+                }
             }
             else
             {
@@ -180,11 +320,13 @@ namespace Microsoft.Contracts.Foxtrot
                     consArgs.Add(this.closureClass.DeclaringType.ConsolidatedTemplateParameters[i]);
                 }
 
-                var methodCount = from.TemplateParameters == null ? 0 : from.TemplateParameters.Count;
-                for (int i = 0; i < methodCount; i++)
+                if (!enclosingTemplateParameters.IsNullOrEmpty())
                 {
-                    consArgs.Add(from.TemplateParameters[i]);
-                    args.Add(from.TemplateParameters[i]);
+                    for (int i = 0; i < enclosingTemplateParameters.Count; i++)
+                    {
+                        consArgs.Add(enclosingTemplateParameters[i]);
+                        args.Add(enclosingTemplateParameters[i]);
+                    } 
                 }
 
                 this.closureClassInstance =
@@ -197,8 +339,7 @@ namespace Microsoft.Contracts.Foxtrot
             this.closureLocal = new Local(this.ClosureClass);
             this.ClosureInitializer = new Block(new StatementList());
 
-            // TODO: What is this?
-            // Add ClosureLocal instantiation?
+            // Generate constructor call that initializes closure instance
             this.ClosureInitializer.Statements.Add(
                 new AssignmentStatement(
                     this.closureLocal,
@@ -218,8 +359,6 @@ namespace Microsoft.Contracts.Foxtrot
             Contract.Requires(returnBlock != null);
             Contract.Requires(taskBasedResult != null);
             Contract.Requires(asyncPostconditions.Count > 0);
-
-            Contract.Assume(taskBasedResult.Type == checkMethodTaskType);
 
             // Async postconditions are impelemented using custom closure class
             // with CheckPost method that checks postconditions when the task
@@ -262,20 +401,24 @@ namespace Microsoft.Contracts.Foxtrot
         {
             get { return (InstanceInitializer)this.closureClassInstance.GetMembersNamed(StandardIds.Ctor)[0]; }
         }
-        
+
         [Pure]
-        private static TypeNodeList CreateTemplateParameters(Class closureClass, Method @from, TypeNode declaringType)
+        private static TypeNodeList CreateTemplateParameters(Class closureClass, TypeNodeList inputTemplateParameters, TypeNode declaringType)
         {
+            Contract.Requires(closureClass != null);
+            Contract.Requires(inputTemplateParameters != null);
+            Contract.Requires(declaringType != null);
+
             var dup = new Duplicator(declaringType.DeclaringModule, declaringType);
 
             var templateParameters = new TypeNodeList();
 
             var parentCount = declaringType.ConsolidatedTemplateParameters.CountOrDefault();
 
-            for (int i = 0; i < from.TemplateParameters.Count; i++)
+            for (int i = 0; i < inputTemplateParameters.Count; i++)
             {
                 var tp = HelperMethods.NewEqualTypeParameter(
-                    dup, (ITypeParameter)from.TemplateParameters[i],
+                    dup, (ITypeParameter)inputTemplateParameters[i],
                     closureClass, parentCount + i);
 
                 templateParameters.Add(tp);
@@ -446,6 +589,15 @@ namespace Microsoft.Contracts.Foxtrot
 
             Method contractEnsuresMethod = this.rewriter.RuntimeContracts.EnsuresMethod;
 
+            // For generic types need to 'fix' generic type parameters that are used in the closure method. 
+            // See comment to the GenericTypeMapper for more details.
+            TypeParameterFixerVisitor fixer = null;
+
+            if (!this.genericTypeMapper.IsEmpty)
+            {
+                fixer = new TypeParameterFixerVisitor(genericTypeMapper);
+            }
+
             foreach (Ensures e in GetTaskResultBasedEnsures(asyncPostconditions))
             {
                 // TODO: Not sure that 'break' is enough! It seems that this is possible
@@ -461,6 +613,11 @@ namespace Microsoft.Contracts.Foxtrot
                 //
 
                 ExpressionList args = new ExpressionList();
+                if (fixer != null)
+                {
+                    fixer.Visit(e.PostCondition);
+                }
+
                 args.Add(e.PostCondition);
 
                 args.Add(e.UserMessage ?? Literal.Null);
@@ -504,7 +661,10 @@ namespace Microsoft.Contracts.Foxtrot
             methodBodyBlock.Statements.Add(new Block(checkStatusStatements));
 
             // Emit a check for __ContractsRuntime.insideContractEvaluation around Ensures
-            this.rewriter.EmitRecursionGuardAroundChecks(this.checkPostMethod, methodBodyBlock, ensuresChecks);
+            // TODO ST: there is no sense to add recursion check in async postcondition that can be checked in different thread!
+            methodBodyBlock.Statements.Add(new Block(ensuresChecks));
+            // Emit a check for __ContractsRuntime.insideContractEvaluation around Ensures
+            //this.rewriter.EmitRecursionGuardAroundChecks(this.checkPostMethod, methodBodyBlock, ensuresChecks);
 
             // Now, normal postconditions are written to the method body. 
             // We need to add endOfNormalPostcondition block as a marker.
@@ -572,6 +732,71 @@ namespace Microsoft.Contracts.Foxtrot
             methodBody.Add(returnBlock);
         }
 
+        /// <summary>
+        /// Helper visitor class that changes all references to type parameters to appropriate once.
+        /// </summary>
+        private class TypeParameterFixerVisitor : StandardVisitor
+        {
+            private readonly GenericTypeMapper genericParametersMapping;
+
+            public TypeParameterFixerVisitor(GenericTypeMapper genericParametersMapping)
+            {
+                Contract.Requires(genericParametersMapping != null);
+                this.genericParametersMapping = genericParametersMapping;
+            }
+
+            // Literal is used when contract result compares to null: Contract.Result<T>() != null
+            public override Expression VisitLiteral(Literal literal)
+            {
+                var origin = literal.Value as TypeNode;
+                if (origin == null)
+                {
+                    return base.VisitLiteral(literal);
+                }
+
+                var newLiteralType = this.genericParametersMapping.GetClosureTypeParameterByEnclosingTypeParameter(origin);
+                if (newLiteralType != origin)
+                {
+                    return new Literal(newLiteralType);
+                }
+
+                return base.VisitLiteral(literal);
+            }
+
+            public override TypeNode VisitTypeParameter(TypeNode typeParameter)
+            {
+                var fixedVersion = this.genericParametersMapping.GetClosureTypeParameterByEnclosingTypeParameter(typeParameter);
+                if (fixedVersion != typeParameter)
+                {
+                    return fixedVersion;
+                }
+
+                return base.VisitTypeParameter(typeParameter);
+            }
+
+            public override TypeNode VisitTypeReference(TypeNode type)
+            {
+                var fixedVersion = this.genericParametersMapping.GetClosureTypeParameterByEnclosingTypeParameter(type);
+                if (fixedVersion != type)
+                {
+                    return fixedVersion;
+                }
+
+                return base.VisitTypeReference(type);
+            }
+
+            public override TypeNode VisitTypeNode(TypeNode typeNode)
+            {
+                var fixedVersion = this.genericParametersMapping.GetClosureTypeParameterByEnclosingTypeParameter(typeNode);
+                if (fixedVersion != typeNode)
+                {
+                    return fixedVersion;
+                }
+
+                return base.VisitTypeNode(typeNode);
+            }
+        }
+
         private static IEnumerable<Ensures> GetTaskResultBasedEnsures(List<Ensures> asyncPostconditions)
         {
             return asyncPostconditions.Where(post => !(post is EnsuresExceptional));
@@ -586,7 +811,7 @@ namespace Microsoft.Contracts.Foxtrot
         /// Returns TaskExtensions.Unwrap method.
         /// </summary>
         [Pure]
-        private static Member GetUnwrapMethod(TypeNode checkMethodTaskType)
+        private Member GetUnwrapMethod(TypeNode checkMethodTaskType)
         {
             Contract.Requires(checkMethodTaskType != null);
             Contract.Ensures(Contract.Result<Member>() != null);
@@ -614,7 +839,17 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 // We need to "instantiate" generic first.
                 // I.e. for Task<int> we need to have Unwrap(Task<Task<int>>): Task<int>
-                return genericUnwrapCandidate.GetTemplateInstance(null, checkMethodTaskType.TemplateArguments[0]);
+                
+                // In this case we need to map back generic types.
+                // CheckPost method is a non-generic method from (potentially) generic closure class.
+                // In this case, if enclosing method is generic we need to map generic types back
+                // and use !!0 (reference to method template arg) instead of using !0 (which is reference
+                // to closure class template arg).
+                var enclosingGeneritType = 
+                    this.genericTypeMapper.GetEnclosingTypeParamterByGenericTypeParameter(
+                        checkMethodTaskType.TemplateArguments[0]);
+
+                return genericUnwrapCandidate.GetTemplateInstance(null, enclosingGeneritType);
             }
 
             return nonGenericUnwrapCandidate;

--- a/Foxtrot/Driver/Rewriting/Utils/TypeNodeExtensions.cs
+++ b/Foxtrot/Driver/Rewriting/Utils/TypeNodeExtensions.cs
@@ -26,5 +26,10 @@ namespace Microsoft.Contracts.Foxtrot.Utils
         {
             return list == null ? 0 : list.Count;
         }
+
+        public static bool IsNullOrEmpty(this TypeNodeList list)
+        {
+            return list == null || list.Count == 0;
+        }
     }
 }

--- a/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericClass.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericClass.cs
@@ -22,32 +22,13 @@ namespace Tests.Sources
 {
     using System.Threading.Tasks;
 
-    class Foo
+    class FooClass<T> where T: class
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        public static Task<T> Foo(T source)
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<T>() != null);
 
-            await Task.Delay(42);
-
-            throw new InvalidOperationException();
-
-            return 42;
-        }
-
-        public static async Task HandleFooAsync()
-        {
-            try
-            {
-                // When async postcondition are implemented properly
-                // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
-            }
-            catch (InvalidOperationException)
-            {
-                Console.WriteLine("Exception should be handled!");
-            }
+            return Task.FromResult(source);
         }
     }
 
@@ -57,15 +38,15 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                FooClass<object>.Foo(new object()).Wait();
             }
             else
             {
-                throw new ArgumentNullException();
+                FooClass<object>.Foo(null).Wait();
             }
         }
 
-        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
-        public string NegativeExpectedCondition = "Value cannot be null.";
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Postcondition;
+        public string NegativeExpectedCondition = "Contract.Result<T>() != null";
     }
 }

--- a/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericClass2.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericClass2.cs
@@ -22,32 +22,13 @@ namespace Tests.Sources
 {
     using System.Threading.Tasks;
 
-    class Foo
+    class FooClass<T, U> where U: class
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        public static Task<U> Foo(U source)
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<U>() != null);
 
-            await Task.Delay(42);
-
-            throw new InvalidOperationException();
-
-            return 42;
-        }
-
-        public static async Task HandleFooAsync()
-        {
-            try
-            {
-                // When async postcondition are implemented properly
-                // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
-            }
-            catch (InvalidOperationException)
-            {
-                Console.WriteLine("Exception should be handled!");
-            }
+            return Task.FromResult(source);
         }
     }
 
@@ -57,15 +38,15 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                FooClass<string, object>.Foo(new object()).Wait();
             }
             else
             {
-                throw new ArgumentNullException();
+                FooClass<string, object>.Foo(null).Wait();
             }
         }
 
-        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
-        public string NegativeExpectedCondition = "Value cannot be null.";
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Postcondition;
+        public string NegativeExpectedCondition = "Contract.Result<U>() != null";
     }
 }

--- a/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethod.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethod.cs
@@ -22,32 +22,13 @@ namespace Tests.Sources
 {
     using System.Threading.Tasks;
 
-    class Foo
+    class FooClass
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        public static Task<T> Foo<T>(T source) where T : class
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<T>() != null);
 
-            await Task.Delay(42);
-
-            throw new InvalidOperationException();
-
-            return 42;
-        }
-
-        public static async Task HandleFooAsync()
-        {
-            try
-            {
-                // When async postcondition are implemented properly
-                // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
-            }
-            catch (InvalidOperationException)
-            {
-                Console.WriteLine("Exception should be handled!");
-            }
+            return Task.FromResult(source);
         }
     }
 
@@ -57,15 +38,16 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                FooClass.Foo(new object()).Wait();
             }
             else
             {
-                throw new ArgumentNullException();
+                FooClass.Foo<object>(null).Wait();
+                // throw new ArgumentNullException();
             }
         }
 
-        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
-        public string NegativeExpectedCondition = "Value cannot be null.";
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Postcondition;
+        public string NegativeExpectedCondition = "Contract.Result<T>() != null";
     }
 }

--- a/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethod2.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethod2.cs
@@ -22,32 +22,13 @@ namespace Tests.Sources
 {
     using System.Threading.Tasks;
 
-    class Foo
+    class FooClass
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        public static Task<U> Foo<T, U>(U source) where U : class
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<U>() != null);
 
-            await Task.Delay(42);
-
-            throw new InvalidOperationException();
-
-            return 42;
-        }
-
-        public static async Task HandleFooAsync()
-        {
-            try
-            {
-                // When async postcondition are implemented properly
-                // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
-            }
-            catch (InvalidOperationException)
-            {
-                Console.WriteLine("Exception should be handled!");
-            }
+            return Task.FromResult(source);
         }
     }
 
@@ -57,15 +38,16 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                FooClass.Foo<string, object>(new object()).Wait();
             }
             else
             {
-                throw new ArgumentNullException();
+                FooClass.Foo<string, object>(null).Wait();
+                // throw new ArgumentNullException();
             }
         }
 
-        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
-        public string NegativeExpectedCondition = "Value cannot be null.";
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Postcondition;
+        public string NegativeExpectedCondition = "Contract.Result<U>() != null";
     }
 }

--- a/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethod3.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethod3.cs
@@ -22,32 +22,14 @@ namespace Tests.Sources
 {
     using System.Threading.Tasks;
 
-    class Foo
+    class FooClass
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        public Task<U> Foo<T, U>(U source) where U : class where T: U
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<U>() != null);
+            Contract.Ensures((T)Contract.Result<U>() != null);
 
-            await Task.Delay(42);
-
-            throw new InvalidOperationException();
-
-            return 42;
-        }
-
-        public static async Task HandleFooAsync()
-        {
-            try
-            {
-                // When async postcondition are implemented properly
-                // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
-            }
-            catch (InvalidOperationException)
-            {
-                Console.WriteLine("Exception should be handled!");
-            }
+            return Task.FromResult(source);
         }
     }
 
@@ -57,15 +39,16 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                new FooClass().Foo<string, object>("foo").Wait();
             }
             else
             {
-                throw new ArgumentNullException();
+                new FooClass().Foo<string, object>(null).Wait();
+                // throw new ArgumentNullException();
             }
         }
 
-        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
-        public string NegativeExpectedCondition = "Value cannot be null.";
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Postcondition;
+        public string NegativeExpectedCondition = "Contract.Result<U>() != null";
     }
 }

--- a/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethodInStruct.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/AsyncPostconditionInGenericMethodInStruct.cs
@@ -22,32 +22,13 @@ namespace Tests.Sources
 {
     using System.Threading.Tasks;
 
-    class Foo
+    struct FooStruct
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        public Task<T> Foo<T>(T source) where T : class
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<T>() != null);
 
-            await Task.Delay(42);
-
-            throw new InvalidOperationException();
-
-            return 42;
-        }
-
-        public static async Task HandleFooAsync()
-        {
-            try
-            {
-                // When async postcondition are implemented properly
-                // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
-            }
-            catch (InvalidOperationException)
-            {
-                Console.WriteLine("Exception should be handled!");
-            }
+            return Task.FromResult(source);
         }
     }
 
@@ -57,15 +38,15 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                new FooStruct().Foo(new object()).Wait();
             }
             else
             {
-                throw new ArgumentNullException();
+                new FooStruct().Foo<object>(null).Wait();
             }
         }
 
-        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
-        public string NegativeExpectedCondition = "Value cannot be null.";
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Postcondition;
+        public string NegativeExpectedCondition = "Contract.Result<T>() != null";
     }
 }

--- a/Foxtrot/Tests/AsyncPostconditions/ExceptionalAsyncPostconditionInGenericMethod.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/ExceptionalAsyncPostconditionInGenericMethod.cs
@@ -24,25 +24,26 @@ namespace Tests.Sources
 
     class Foo
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        
+        private Task<T> FooAsync<T>(T t) where T: class
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<T>() != null);
 
-            await Task.Delay(42);
+            //await Task.Delay(42);
 
             throw new InvalidOperationException();
 
-            return 42;
+            //return t;
         }
 
-        public static async Task HandleFooAsync()
+        public static async Task HandleFooAsync(string arg)
         {
             try
             {
                 // When async postcondition are implemented properly
                 // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
+                await new Foo().FooAsync(arg);
+                await Task.Delay(42);
             }
             catch (InvalidOperationException)
             {
@@ -57,7 +58,7 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                Foo.HandleFooAsync("foo").Wait();
             }
             else
             {

--- a/Foxtrot/Tests/AsyncPostconditions/ExceptionalAsyncPostconditionInGenericMethod2.cs
+++ b/Foxtrot/Tests/AsyncPostconditions/ExceptionalAsyncPostconditionInGenericMethod2.cs
@@ -24,25 +24,24 @@ namespace Tests.Sources
 
     class Foo
     {
-        private static int _expectedResult = 42;
-        private async Task<int> FooAsync()
+        private async Task<T> FooAsync<T>(T t) where T: class
         {
-            Contract.Ensures(Contract.Result<int>() == _expectedResult);
+            Contract.Ensures(Contract.Result<T>() != null);
 
             await Task.Delay(42);
 
             throw new InvalidOperationException();
 
-            return 42;
+            //return t;
         }
 
-        public static async Task HandleFooAsync()
+        public static async Task HandleFooAsync(string arg)
         {
             try
             {
                 // When async postcondition are implemented properly
                 // they should not affect exception handling when the method throws.
-                await new Foo().FooAsync();
+                await new Foo().FooAsync(arg);
             }
             catch (InvalidOperationException)
             {
@@ -57,7 +56,7 @@ namespace Tests.Sources
         {
             if (behave)
             {
-                Foo.HandleFooAsync().Wait();
+                Foo.HandleFooAsync("foo").Wait();
             }
             else
             {

--- a/Foxtrot/Tests/ExtractorTests/ExtractorTest.cs
+++ b/Foxtrot/Tests/ExtractorTests/ExtractorTest.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Tests
+namespace Tests.ExtractorTests
 {
     /// <summary>
     /// Unit tests for ExtractorTests

--- a/Foxtrot/Tests/FoxtrotTests10.csproj
+++ b/Foxtrot/Tests/FoxtrotTests10.csproj
@@ -93,10 +93,8 @@
   <ItemGroup>
     <None Include="CheckerTests\CheckerErrors.cs" />
     <Compile Include="CRASanitizeTest.cs" />
-    <Compile Include="ExtractorTest.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RewriterTests.cs" />
     <None Include="packages.config" />
     <None Include="Sources\InheritPreInterface.cs" />
     <TestSources Include="Sources\OOBInterfacePreGeneric.cs" />
@@ -115,6 +113,8 @@
     <TestSources Include="Sources\InterleavedValidationsInherit.cs" />
     <TestSources Include="Sources\IteratorWithLegacyPrecondition.cs" />
     <TestSources Include="Sources\DefaultExpression.cs" />
+    <Compile Include="RewriterTests\AsyncTestsDataSource.cs" />
+    <Compile Include="RewriterTests\RewriterTest.cs" />
     <Compile Include="TestDriver.cs" />
     <TestSources Include="Sources\InheritExists.cs" />
     <TestSources Include="Sources\InheritGenericExists.cs" />

--- a/Foxtrot/Tests/Options.cs
+++ b/Foxtrot/Tests/Options.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 
@@ -247,6 +248,23 @@ namespace Tests
             this.MustSucceed = mustSucceed;
 
             this.RootDirectory = Path.GetFullPath(RelativeRoot);
+        }
+
+        public Options WithSourceFile(string sourceFile)
+        {
+            Contract.Requires(!string.IsNullOrEmpty(sourceFile));
+
+            return new Options(
+                    sourceFile: sourceFile,
+                    foxtrotOptions: FoxtrotOptions,
+                    useContractReferenceAssemblies: UseContractReferenceAssemblies,
+                    compilerOptions: CompilerOptions,
+                    references: References.ToArray(),
+                    libPaths: LibPaths.ToArray(),
+                    compilerCode: compilerCode,
+                    useBinDir: UseBinDir,
+                    useExe: UseExe,
+                    mustSucceed: MustSucceed);
         }
 
         public bool ReleaseMode { get; set; }

--- a/Foxtrot/Tests/RewriterTests/AsyncTestsDataSource.cs
+++ b/Foxtrot/Tests/RewriterTests/AsyncTestsDataSource.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Tests
+{
+    internal sealed class AsyncTestsDataSource
+    {
+        private static readonly Options OptionsTemplate = new Options(
+                    sourceFile: @"dummy_file",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new[] { @"System.dll", @"System.Core.dll", @"System.Threading.Tasks.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+
+        public static string[] SourceFiles = new[]
+        {
+            @"Foxtrot\Tests\AsyncTests\AsyncWithoutAwait.cs",
+            @"Foxtrot\Tests\AsyncTests\AsyncInGenericClass.cs",
+            @"Foxtrot\Tests\AsyncTests\AsyncInGenericClass.cs",
+            @"Foxtrot\Tests\AsyncTests\AsyncEnsuresWithInterface.cs",
+        };
+
+        public static IEnumerable<Options> BaseTestCases
+        {
+            get
+            {
+                var sourceFiles = new[]
+                {
+                    @"Foxtrot\Tests\AsyncTests\AsyncWithoutAwait.cs",
+                    @"Foxtrot\Tests\AsyncTests\AsyncInGenericClass.cs",
+                    @"Foxtrot\Tests\AsyncTests\AsyncInGenericClass.cs",
+                    @"Foxtrot\Tests\AsyncTests\AsyncEnsuresWithInterface.cs",
+                };
+
+                return sourceFiles.Select(f => OptionsTemplate.WithSourceFile(f));
+            }
+        }
+
+        public static IEnumerable<Options> AsyncPostconditionsTestCases
+        {
+            get
+            {
+                var sourceFiles = new[]
+                {
+                    @"Foxtrot\Tests\AsyncPostconditions\AsyncPostconditionInGenericClass.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\AsyncPostconditionInGenericClass2.cs",
+
+                    @"Foxtrot\Tests\AsyncPostconditions\AsyncPostconditionInGenericMethod.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\AsyncPostconditionInGenericMethod2.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\AsyncPostconditionInGenericMethod3.cs",
+
+                    @"Foxtrot\Tests\AsyncPostconditions\AsyncPostconditionInGenericMethodInStruct.cs",
+
+                    @"Foxtrot\Tests\AsyncPostconditions\CancelledAsyncPostcondition.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\AsyncPostconditionsInInterface.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\MixedAsyncPostcondition.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\NormalAsyncPostcondition.cs",
+                    
+                    @"Foxtrot\Tests\AsyncPostconditions\ExceptionalAsyncPostcondition.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\ExceptionalAsyncPostconditionInGenericMethod.cs",
+                    @"Foxtrot\Tests\AsyncPostconditions\ExceptionalAsyncPostconditionInGenericMethod2.cs",
+                };
+
+                return sourceFiles.Select(f => OptionsTemplate.WithSourceFile(f));
+            }
+        }
+    }
+}

--- a/Foxtrot/Tests/RewriterTests/RewriterTest.cs
+++ b/Foxtrot/Tests/RewriterTests/RewriterTest.cs
@@ -1,0 +1,1978 @@
+// CodeContracts
+// 
+// Copyright (c) Microsoft Corporation
+// 
+// All rights reserved. 
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    /// <summary>
+    /// Unit tests for ccrewriter a.k.a. Foxtrot
+    /// </summary>
+    public class RewriterTest
+    {
+        const string FrameworkBinariesToRewritePath = @"Foxtrot\Tests\RewriteExistingBinaries\";
+
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public RewriterTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        #region Test Data
+
+        public static IEnumerable<object> AsyncTests
+        {
+            get
+            {
+                return Enumerable.Range(0, AsyncTestsDataSource.BaseTestCases.Count()).Select(i => new object[] { i });
+            }
+        }
+
+        public static IEnumerable<object> AsyncPostconditions
+        {
+            get
+            {
+                return Enumerable.Range(0, AsyncTestsDataSource.AsyncPostconditionsTestCases.Count()).Select(i => new object[] { i });
+            }
+        }
+
+
+        private static IEnumerable<Options> TestFileData
+        {
+            get
+            {
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\RequiresForAll.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\ComplexGeneric.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\PostAmbleDeletion.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\StaticOldValue.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\AbbrevGenLit.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\AbbrevGenClosure.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\ClosureOnlyBody.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\ClosureCtor.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\GenericInterfaceMethods.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\GenericConstraints.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\DupTest.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\ContractClassRemnants.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritClosureMatchingExistingClosure.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InvariantOnCtorThrow.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritRequirePublicSurface.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\ClosureAfterRequires.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\TestClosureDeletion.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\ClosureDeletionWithAbbrev.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async1.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async1.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async2.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async2.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async3.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async3.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async4.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async4.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async5.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async5.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async6.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async6.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async6b.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async6b.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async7.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async7.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async8.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async8.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async9.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async9.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async10.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async10.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async11.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async11.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async12.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async12.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async_EnsuresWithCapturedForAll.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Iterator1.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Iterator1.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Iterator2.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Iterator2.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Iterator3.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Iterator3.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritHiddenEnsures.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\BaseInvariantDelayed.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\GenericInstanceClosure.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericTypeProtected.cs",
+                    foxtrotOptions: @"/csr",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/d:LOCALBASE",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericProtected.cs",
+                    foxtrotOptions: @"/csr",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/d:LOCALBASE",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritOOBProtected.cs",
+                    foxtrotOptions: @"/csr",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/d:LOCALBASE",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritOOBClosure.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AssemblyWithContracts.dll" },
+                    libPaths: @"Foxtrot\Tests\AssemblyWithContracts\bin\Debug".Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\IteratorWithLegacyPrecondition.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\DefaultParameter.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\DefaultExpression.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericAbstractClass.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericAbstractClass.cs",
+                    foxtrotOptions: @"/csr",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericClosurePre.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericClosurePre.cs",
+                    foxtrotOptions: @"/csr",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritExists.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AssemblyWithContracts.dll" },
+                    libPaths: @"Foxtrot\Tests\AssemblyWithContracts\bin\Debug".Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritForall.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"AssemblyWithContracts.dll" },
+                    libPaths: @"Foxtrot\Tests\AssemblyWithContracts\bin\Debug".Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                    compilerCode: "",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericExists.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"AssemblyWithContracts.dll" },
+                    libPaths: @"Foxtrot\Tests\AssemblyWithContracts\bin\Debug".Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                    compilerCode: "",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritGenericForall.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"AssemblyWithContracts.dll" },
+                    libPaths: @"Foxtrot\Tests\AssemblyWithContracts\bin\Debug".Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                    compilerCode: "",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritPost.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritPre.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritPreEx.cs",
+                    foxtrotOptions: @"-assemblyMode=standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritPreLegacy.cs",
+                    foxtrotOptions: @"-assemblyMode=standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritPreLegacyManual.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InterleavedValidations.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InterleavedValidationsInherit.cs",
+                    foxtrotOptions: @"-assemblyMode=standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\OOBinterfacePost.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\OOBInterfacePre.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\OOBInterfacePreGeneric.cs",
+                    foxtrotOptions: @"/callsiterequires",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new[] { @"AssemblyWithContracts.dll", @"System.Core.dll" },
+                    libPaths: @"Foxtrot\Tests\AssemblyWithContracts\bin\Debug".Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\OOBPost.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\OOBPre.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritPreInterface.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritClosureWithStelem.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritClosureWithStelem.cs",
+                    foxtrotOptions: @"/callsiterequires",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+            }
+        }
+
+        public static IEnumerable<object> TestFile
+        {
+            get
+            {
+                return Enumerable.Range(0, TestFileData.Count()).Select(i => new object[] { i });
+            }
+        }
+
+
+        private static IEnumerable<Options> RoslynCompatibilityData
+        {
+            get
+            {
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\ExpressionsInRequires.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll", @"System.Linq.Expressions.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\AsyncWithLegacyRequires.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\AsyncRequiresWithMultipleAwaits.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\InheritOOBClosure.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AssemblyWithContracts.dll" },
+                    libPaths: @"Foxtrot\Tests\AssemblyWithContracts\bin\Debug".Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\Async12.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"/optimize",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\AbbrevGenClosure.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\CapturingContractResult.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\RequiresForAll.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\InheritNonGenericAbstractClass.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\AsyncRequiresWithForAll.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: null,
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\AsyncWithoutContract.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: null,
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\InheritGenericAbstractClass.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: null,
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\CapturingAsyncLambda.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: null,
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+            }
+        }
+
+        public static IEnumerable<object> RoslynCompatibility
+        {
+            get
+            {
+                return Enumerable.Range(0, RoslynCompatibilityData.Count()).Select(i => new object[] { i });
+            }
+        }
+
+
+        private static IEnumerable<Options> IteratorWithComplexGenericData
+        {
+            get
+            {
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\RoslynCompatibility\IteratorWithTuple.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+            }
+        }
+
+        public static IEnumerable<object> IteratorWithComplexGeneric
+        {
+            get
+            {
+                return Enumerable.Range(0, IteratorWithComplexGenericData.Count()).Select(i => new object[] { i });
+            }
+        }
+
+
+        private static IEnumerable<Options> RewriteExistingData
+        {
+            get
+            {
+                yield return new Options(
+                    sourceFile: @"mscorlib.dll",
+                    foxtrotOptions: @"/throwonfailure=false",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.AddIn.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Core.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Design.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Xml.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Microsoft.VisualStudio.Utilities.v11.0.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.ComponentModel.Composition.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Drawing.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.IO.Compression.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.IO.Compression.FileSystem.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Net.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Net.Http.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Net.Http.WebRequestdll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Numerics.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Reflection.Context.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Runtime.WindowsRuntime.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"System.Runtime.WindowsRuntime.UI.Xaml.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"VerifyWin8P.dll",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+            }
+        }
+
+        public static IEnumerable<object> RewriteExisting
+        {
+            get
+            {
+                return Enumerable.Range(0, RewriteExistingData.Count()).Select(i => new object[] { i });
+            }
+        }
+
+
+        private static IEnumerable<Options> TestConfigurationData
+        {
+            get
+            {
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:0 /throwonfailure=false",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:1 /throwonfailure=false",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:2 /throwonfailure=false",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:3 /throwonfailure=false",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:4 /throwonfailure=false",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:0 /throwonfailure=true",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:1 /throwonfailure=true",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:2 /throwonfailure=true",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:3 /throwonfailure=true",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:4 /throwonfailure=true",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:0 /throwonfailure=true /callsiterequires",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:1 /throwonfailure=true /callsiterequires",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:2 /throwonfailure=true /callsiterequires",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:3 /throwonfailure=true /callsiterequires",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"",
+                    foxtrotOptions: @"/level:4 /throwonfailure=true /callsiterequires",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
+            }
+        }
+
+        public static IEnumerable<object> TestConfiguration
+        {
+            get
+            {
+                return Enumerable.Range(0, TestConfigurationData.Count()).Select(i => new object[] { i });
+            }
+        }
+
+
+        private static IEnumerable<Options> PublicSurfaceOnlyData
+        {
+            get
+            {
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\PublicSurfaceOnly\IteratorWithComplexPrecondition.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: false);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\PublicSurfaceOnly\AsyncMethodWithComplexPrecondition.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new[] { @"AsyncCtpLibrary.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: false);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\PublicSurfaceOnly\CallPrivateRequiresShouldNotFail.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: false);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\PublicSurfaceOnly\CallPrivateEnsuresShouldNotFail.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: false,
+                    compilerOptions: @"",
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: false);
+            }
+        }
+
+        public static IEnumerable<object> PublicSurfaceOnly
+        {
+            get
+            {
+                return Enumerable.Range(0, PublicSurfaceOnlyData.Count()).Select(i => new object[] { i });
+            }
+        }
+        #endregion
+
+        #region Async tests
+        [Theory]
+        [MemberData("AsyncTests")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "VS14")]
+        public void AsyncTestsWithRoslynCompiler(int testIndex)
+        {
+            Options options = AsyncTestsDataSource.BaseTestCases.ElementAt(testIndex);
+            CreateRoslynOptions(options, "VS14RC3");
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("AsyncTests")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V4.5")]
+        public void AsyncTestsWithDotNet45(int testIndex)
+        {
+            Options options = AsyncTestsDataSource.BaseTestCases.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        #endregion
+        [Theory]
+        [MemberData("AsyncPostconditions")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "VS14")]
+        public void TestAsyncPostconditionsWithRoslyn(int testIndex)
+        {
+            Options options = AsyncTestsDataSource.AsyncPostconditionsTestCases.ElementAt(testIndex);
+            CreateRoslynOptions(options, "VS14RC3");
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        // TODO ST: it seems that the Trait("Category", "Roslyn" is invalid for this test! And VS14 as well!
+        [Theory]
+        [MemberData("AsyncPostconditions")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "VS14")]
+        public void TestAsyncPostconditionsV45(int testIndex)
+        {
+            Options options = AsyncTestsDataSource.AsyncPostconditionsTestCases.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        #region Roslyn compiler unit tests
+        [Theory]
+        [MemberData("TestFile")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "VS14")]
+        public void Roslyn_BuildRewriteRunFromSources(int testIndex)
+        {
+            Options options = TestFileData.ElementAt(testIndex);
+            CreateRoslynOptions(options, "VS14RC3");
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("RoslynCompatibility")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "VS14")]
+        public void Roslyn_CompatibilityCheck(int testIndex)
+        {
+            Options options = RoslynCompatibilityData.ElementAt(testIndex);
+            CreateRoslynOptions(options, "VS14RC3");
+
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("RoslynCompatibility")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V4.5")]
+        public void TestTheRoslynCompatibilityCasesWithVS2013Compiler(int testIndex)
+        {
+            Options options = RoslynCompatibilityData.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("RoslynCompatibility")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "VS14")]
+        public void Roslyn_CompatibilityCheckInReleaseMode(int testIndex)
+        {
+            Options options = RoslynCompatibilityData.ElementAt(testIndex);
+            CreateRoslynOptions(options, "VS14RC3");
+
+            options.CompilerOptions = "/optimize";
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        /// <summary>
+        /// Unit test for #47 - "Could not resolve type reference" for some iterator methods in VS2015 and
+        /// #186 - ccrewrite produces an incorrect type name in IteratorStateMachineAttribute with some generic types
+        /// </summary>
+        [Theory]
+        [MemberData("IteratorWithComplexGeneric")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "VS14")]
+        public void Roslyn_IteratorBlockWithComplexGeneric(int testIndex)
+        {
+            Options options = IteratorWithComplexGenericData.ElementAt(testIndex);
+            CreateRoslynOptions(options, "VS14RC3");
+            // Bug with metadata reader could be reproduced only with a new mscorlib and new System.dll.
+            options.BuildFramework = @".NetFramework\v4.6";
+            options.ReferencesFramework = @".NetFramework\v4.6";
+            options.DeepVerify = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        /// <summary>
+        /// Creates <see cref="Options"/> instance with default values suitable for testing roslyn-based compiler.
+        /// </summary>
+        /// <param name="compilerVersion">Should be the same as a folder name in the /Imported/Roslyn folder.</param>
+        private void CreateRoslynOptions(Options options, string compilerVersion)
+        {
+            // For VS14RC+ version compiler name is the same Csc.exe, and behavior from async/iterator perspective is similar
+            // to old compiler as well. That's why IsLegacyRoslyn should be false in this test case.
+            options.IsLegacyRoslyn = false;
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.CompilerPath = string.Format(@"Roslyn\{0}", compilerVersion);
+            options.BuildFramework = @".NetFramework\v4.5";
+            options.ReferencesFramework = @".NetFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.5";
+            options.UseTestHarness = true;
+        }
+
+        #endregion Roslyn compiler unit tests
+
+        [Theory]
+        [MemberData("RewriteExisting")]
+        [Trait("Category", "Runtime"), Trait("Category", "Framework"), Trait("Category", "V4.0"), Trait("Category", "CoreTest")]
+        public void RewriteFrameworkDlls40(int testIndex)
+        {
+            Options options = RewriteExistingData.ElementAt(testIndex);
+            var framework = @".NetFramework\v4.0";
+            options.ContractFramework = framework;
+            var dllpath = FrameworkBinariesToRewritePath + framework;
+            options.BuildFramework = options.MakeAbsolute(dllpath);
+            var extrareferencedir = options.MakeAbsolute(TestDriver.ReferenceDirRoot);
+            options.LibPaths.Add(extrareferencedir);
+            options.FoxtrotOptions = options.FoxtrotOptions + " /verbose:4";
+            options.UseContractReferenceAssemblies = false;
+
+            if (File.Exists(options.MakeAbsolute(Path.Combine(dllpath, options.SourceFile))))
+            {
+                TestDriver.RewriteBinary(_testOutputHelper, options, dllpath);
+            }
+        }
+
+        [Theory]
+        [MemberData("RewriteExisting")]
+        [Trait("Category", "Runtime"), Trait("Category", "Framework"), Trait("Category", "V4.5"), Trait("Category", "CoreTest")]
+        public void RewriteFrameworkDlls45(int testIndex)
+        {
+            Options options = RewriteExistingData.ElementAt(testIndex);
+            var framework = @".NetFramework\v4.5";
+            options.ContractFramework = framework;
+            var dllpath = FrameworkBinariesToRewritePath + framework;
+            var extrareferencedir = options.MakeAbsolute(TestDriver.ReferenceDirRoot);
+            options.LibPaths.Add(extrareferencedir);
+            options.BuildFramework = options.MakeAbsolute(dllpath);
+            options.FoxtrotOptions = options.FoxtrotOptions + " /verbose:4";
+            options.UseContractReferenceAssemblies = false;
+
+            if (File.Exists(options.MakeAbsolute(Path.Combine(dllpath, options.SourceFile))))
+            {
+                TestDriver.RewriteBinary(_testOutputHelper, options, dllpath);
+            }
+        }
+
+        [Theory]
+        [MemberData("TestConfiguration")]
+        [Trait("Category", "Runtime"), Trait("Category", "ThirdParty"), Trait("Category", "CoreTest")]
+        public void RewriteQuickGraph(int testIndex)
+        {
+            Options options = TestConfigurationData.ElementAt(testIndex);
+            //var options = new Options("QuickGraph", (string)TestContext.DataRow["FoxtrotOptions"], TestContext);
+            options.BuildFramework = @".NetFramework\v4.0";
+            TestDriver.RewriteAndVerify(_testOutputHelper, "", @"Foxtrot\Tests\Quickgraph\QuickGraphBinaries\Quickgraph.dll", options);
+        }
+
+        [Theory]
+        [MemberData("TestConfiguration")]
+        [Trait("Category", "Runtime"), Trait("Category", "ThirdParty"), Trait("Category", "CoreTest")]
+        public void RewriteQuickGraphData(int testIndex)
+        {
+            Options options = TestConfigurationData.ElementAt(testIndex);
+            //var options = new Options("QuickGraphData", (string)TestContext.DataRow["FoxtrotOptions"], TestContext);
+            options.BuildFramework = @".NetFramework\v4.0";
+            options.FoxtrotOptions = options.FoxtrotOptions + " /verbose:4";
+            options.Delete(@"Foxtrot\Tests\QuickGraph\QuickGraphBinaries\QuickGraph.Contracts.dll");
+            TestDriver.RewriteAndVerify(_testOutputHelper, "", @"Foxtrot\Tests\Quickgraph\QuickGraphBinaries\Quickgraph.Data.dll", options);
+        }
+
+        [Theory]
+        [MemberData("TestConfiguration")]
+        [Trait("Category", "Runtime"), Trait("Category", "ThirdParty"), Trait("Category", "CoreTest")]
+        public void RewriteQuickGraphDataOOB(int testIndex)
+        {
+            Options options = TestConfigurationData.ElementAt(testIndex);
+            //var options = new Options("QuickGraphDataOOB", (string)TestContext.DataRow["FoxtrotOptions"], TestContext);
+            options.BuildFramework = @".NetFramework\v4.0";
+            options.LibPaths.Add(@"Foxtrot\Tests\QuickGraph\QuickGraphBinaries\Contracts"); // subdirectory containing contracts.
+            options.FoxtrotOptions = options.FoxtrotOptions + " /verbose:4";
+            TestDriver.RewriteAndVerify(_testOutputHelper, "", @"Foxtrot\Tests\Quickgraph\QuickGraphBinaries\Quickgraph.Data.dll", options);
+        }
+
+        [Theory]
+        [MemberData("TestFile")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V3.5")]
+        public void BuildRewriteRunFromSourcesV35(int testIndex)
+        {
+            Options options = TestFileData.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = "v3.5";
+            options.ContractFramework = "v3.5";
+            options.UseTestHarness = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("TestFile")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V4.0")]
+        public void BuildRewriteRunFromSourcesV40(int testIndex)
+        {
+            Options options = TestFileData.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.0";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("TestFile")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V4.5")]
+        public void BuildRewriteRunFromSourcesV45(int testIndex)
+        {
+            Options options = TestFileData.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("RoslynCompatibility")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V4.5")]
+        public void BuildRewriteRunRoslynTestCasesWithV45(int testIndex)
+        {
+            Options options = RoslynCompatibilityData.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory(Skip = "Old Roslyn bits are not compatible with CCRewrite. Test (and old binaries) should be removed in the next iteration.")]
+        [MemberData("TestFile")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "Roslyn"), Trait("Category", "V4.5")]
+        public void BuildRewriteRunFromSourcesRoslynV45(int testIndex)
+        {
+            Options options = TestFileData.ElementAt(testIndex);
+            options.IsLegacyRoslyn = true;
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @"Roslyn\v4.5";
+            options.ReferencesFramework = @".NetFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("TestFile")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V4.0"), Trait("Category", "V3.5")]
+        public void BuildRewriteRunFromSourcesV40AgainstV35Contracts(int testIndex)
+        {
+            Options options = TestFileData.ElementAt(testIndex);
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.0";
+            options.ContractFramework = @"v3.5";
+            options.UseTestHarness = true;
+
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        [Theory]
+        [MemberData("PublicSurfaceOnly")]
+        [Trait("Category", "Runtime"), Trait("Category", "CoreTest"), Trait("Category", "V4.5")]
+        public void BuildRewriteFromSources45WithPublicSurfaceOnly(int testIndex)
+        {
+            Options options = PublicSurfaceOnlyData.ElementAt(testIndex);
+            // For testing purposes you can remove /publicsurface and see what happen. Part of the tests should fail!
+            //options.FoxtrotOptions = options.FoxtrotOptions + String.Format("/throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.FoxtrotOptions = options.FoxtrotOptions + String.Format(" /publicsurface /throwonfailure /rw:{0}.exe,TestInfrastructure.RewriterMethods", Path.GetFileNameWithoutExtension(options.TestName));
+            options.BuildFramework = @".NETFramework\v4.5";
+            options.ContractFramework = @".NETFramework\v4.0";
+            options.UseTestHarness = true;
+
+            TestDriver.BuildRewriteRun(_testOutputHelper, options);
+        }
+
+        //private void GrabTestOptions(out string sourceFile, out string options, out string cscoptions, out List<string> refs, out List<string> libs)
+        //{
+        //    sourceFile = (string)TestContext.DataRow["Name"];
+        //    options = (string)TestContext.DataRow["Options"];
+        //    cscoptions = TestContext.DataRow["CSCOptions"] as string;
+        //    string references = TestContext.DataRow["References"] as string;
+        //    refs = new List<string>(new[] { "System.dll" });
+        //    if (references != null)
+        //    {
+        //        refs.AddRange(references.Split(';'));
+        //    }
+        //    libs = new List<string>();
+        //    string libPaths = TestContext.DataRow["Libpaths"] as string;
+        //    if (libPaths != null)
+        //    {
+        //        libs.AddRange(libPaths.Split(';'));
+        //    }
+        //}
+    }
+}


### PR DESCRIPTION
This PR fixes #235 and #275.

Main change was made for EmitAsyncClosure where special map was added to correlate potentially different generic types that can be used in CheckPost method.
